### PR TITLE
macOS: silent exit when no argv[1]

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -1,5 +1,5 @@
 const { isMac } = require('which-runtime')
-if (isMac && !process.argv[1]) process.exit(0) // silent exit when "Re-open windows when logging in"
+if (isMac && !process.argv[1]) process.exit(0) // silent exit for "Re-open windows when logging in"
 const fs = require('fs')
 const path = require('path')
 const { pathToFileURL } = require('url')

--- a/boot.js
+++ b/boot.js
@@ -1,3 +1,5 @@
+const { isMac } = require('which-runtime')
+if (isMac && !process.argv[1]) process.exit(0) // silent exit when "Re-open windows when logging in"
 const fs = require('fs')
 const path = require('path')
 const { pathToFileURL } = require('url')

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "bare-bundle": "^1.8.3",
-    "bare-bundle-evaluate": "^1.2.0"
+    "bare-bundle-evaluate": "^1.2.0",
+    "which-runtime": "^1.3.2"
   }
 }


### PR DESCRIPTION
* Tested: regular appling click-launch (gets `argv[1]`)

* Tested: macOS restart, silent exits (not even dock icon appears/jumps, doesn't get `argv[1]`)